### PR TITLE
Fix wrong scan index in VMF1/VMF3 fallback for station 2

### DIFF
--- a/src/ivg/obs.cpp
+++ b/src/ivg/obs.cpp
@@ -404,7 +404,7 @@ void Obs::calc_delay( vector<double>::iterator design_iter, vector<double>::iter
             _scan->_data.at( _sta1_scan_idx ).tropo.calc_vmf1( azel1(1), interpolation_type, mf_hydr1, mf_wet1 );
         
         if(sta2->get_data_status("VMF1") == "W")
-            _scan->_data.at( _sta1_scan_idx ).tropo.calc_vmf1_gpt2( azel2(1), mf_hydr2, mf_wet2 );
+            _scan->_data.at( _sta2_scan_idx ).tropo.calc_vmf1_gpt2( azel2(1), mf_hydr2, mf_wet2 );
         else
             _scan->_data.at( _sta2_scan_idx ).tropo.calc_vmf1( azel2(1), interpolation_type, mf_hydr2, mf_wet2 );
     }
@@ -424,14 +424,14 @@ void Obs::calc_delay( vector<double>::iterator design_iter, vector<double>::iter
 	  }
         
         if(sta2->get_data_status("VMF3") != "X")
-            _scan->_data.at( _sta1_scan_idx ).tropo.calc_vmf3_gpt3( azel2(1), mf_hydr2, mf_wet2 );
+            _scan->_data.at( _sta2_scan_idx ).tropo.calc_vmf3_gpt3( azel2(1), mf_hydr2, mf_wet2 );
         else
 	  {
 	    try {
             _scan->_data.at( _sta2_scan_idx ).tropo.calc_vmf3( azel2(1), interpolation_type, mf_hydr2, mf_wet2 );
 	    }
 	    catch (int e) {
-	      _scan->_data.at( _sta1_scan_idx ).tropo.calc_vmf3_gpt3( azel2(1), mf_hydr2, mf_wet2 );
+	      _scan->_data.at( _sta2_scan_idx ).tropo.calc_vmf3_gpt3( azel2(1), mf_hydr2, mf_wet2 );
 	    }
 	  }
     }


### PR DESCRIPTION
## Summary

Three copy-paste bugs in `calc_delay()` in `obs.cpp`: when station 2 lacks VMF1 or VMF3 gridded data and falls back to GPT2/GPT3, `_sta1_scan_idx` was used instead of `_sta2_scan_idx`. This causes the mapping function to be computed using station 1's troposphere object rather than station 2's.

- VMF1 fallback for sta2: wrong index in `calc_vmf1_gpt2` call
- VMF3 fallback for sta2: wrong index in `calc_vmf3_gpt3` call (primary path)
- VMF3 fallback for sta2: wrong index in `calc_vmf3_gpt3` call (catch block)

The computed `mf_hydr2`/`mf_wet2` values are written correctly by value, but the internal station-specific state (site coordinates, VMF grid data, etc.) read inside the tropo object would be wrong. Only affects sessions where at least one station lacks VMF1/VMF3 data and falls back to GPT.

## Test plan

- [ ] Run a session where station 2 lacks VMF1 data (status "W") and verify mapping functions are now computed from the correct station's tropo object
- [ ] Run a session where station 2 lacks VMF3 data (status != "X") and verify the same
- [ ] Confirm sessions where all stations have full VMF data are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)