### PR TITLE
Implement phase center offset (PCO) correction for phase delay

### DIFF
--- a/src/ivg/obs.cpp
+++ b/src/ivg/obs.cpp
@@ -143,6 +143,13 @@ void Obs::set_feed_rotation( double feed1, double feed2 )
     _scan->_data.at( _sta2_scan_idx ).feed_rotation = feed2;
 }
 // ...........................................................................
+void Obs::set_phase_center_offset( double pco1, double pco2 )
+// ...........................................................................
+{
+    _scan->_data.at( _sta1_scan_idx ).phase_center_height = pco1;
+    _scan->_data.at( _sta2_scan_idx ).phase_center_height = pco2;
+}
+// ...........................................................................
 void Obs::set_cable_cal( double cc1, double cc2 )
 // ...........................................................................
 {
@@ -517,7 +524,15 @@ void Obs::calc_delay( vector<double>::iterator design_iter, vector<double>::iter
       gravdef_2 = _scan->calc_gravdef_delay( _sta2_scan_idx, k2_trf  );
     }
     tau += ( gravdef_2-gravdef_1 );
-   
+
+    // phase center offset correction (phase delay only)
+    if( delaytype == 'p' )
+    {
+        double pco1 = _scan->_data.at( _sta1_scan_idx ).phase_center_height;
+        double pco2 = _scan->_data.at( _sta2_scan_idx ).phase_center_height;
+        tau += ( pco2*sin(azel2(1)) - pco1*sin(azel1(1)) ) / ivg::c;
+    }
+
 //    // TEMPORARY LUCIA SATELLITE COMPARISON OUTPUT
 //    stringstream tmp_out2;
 //    tmp_out2 << " " << setfill(' ') << setw(21)<< right << scientific << setprecision(14) << -1.0 * tau << endl;
@@ -653,6 +668,15 @@ void Obs::calc_delay( vector<double>::iterator design_iter, vector<double>::iter
             _station2)) = 1.0/( tan( azel2(1) )*sin( azel2(1) )+0.0032 )
                           *sin( azel2(0) )*1e-2;
 
+    // PCO [m], phase delay only
+    if( delaytype == 'p' )
+    {
+        *(design_iter+_session->_param_list.get_index(ivg::paramtype::pco, _station1))
+            = -sin(azel1(1)) * 1e-2;
+        *(design_iter+_session->_param_list.get_index(ivg::paramtype::pco, _station2))
+            = +sin(azel2(1)) * 1e-2;
+    }
+
     if (par_aplo)
       {
 	*par_aplo=((dx2_ntaplo(0)-dx1_ntaplo(0))*B(0)+(dx2_ntaplo(1)-dx1_ntaplo(1))*B(1)+(dx2_ntaplo(2)-dx1_ntaplo(2))*B(2))/ivg::c;
@@ -736,8 +760,17 @@ void Obs::calc_delay( vector<double>::iterator design_iter, vector<double>::iter
             = (zhd2+zwd2) / ivg::param_unit_fac.at( ivg::paramtype::zwd );
     *(apriori_iter+_session->_param_list.get_index(ivg::paramtype::ngr,_station2)) 
             = _scan->_data.at( _sta2_scan_idx ).tropo.get_north_gradient() / ivg::param_unit_fac.at( ivg::paramtype::ngr );
-    *(apriori_iter+_session->_param_list.get_index(ivg::paramtype::egr,_station2)) 
-            = _scan->_data.at( _sta2_scan_idx ).tropo.get_east_gradient() / ivg::param_unit_fac.at( ivg::paramtype::egr ); 
+    *(apriori_iter+_session->_param_list.get_index(ivg::paramtype::egr,_station2))
+            = _scan->_data.at( _sta2_scan_idx ).tropo.get_east_gradient() / ivg::param_unit_fac.at( ivg::paramtype::egr );
+    if( delaytype == 'p' )
+    {
+        *(apriori_iter+_session->_param_list.get_index(ivg::paramtype::pco,_station1))
+            = _scan->_data.at(_sta1_scan_idx).phase_center_height
+              / ivg::param_unit_fac.at( ivg::paramtype::pco );
+        *(apriori_iter+_session->_param_list.get_index(ivg::paramtype::pco,_station2))
+            = _scan->_data.at(_sta2_scan_idx).phase_center_height
+              / ivg::param_unit_fac.at( ivg::paramtype::pco );
+    }
     // station coordinates
     ivg::Matrix sta2xyz =sta2->calc_xyz(_epoch,{"PSD","SEASONALS"});
      *(apriori_iter+_session->_param_list.get_index(ivg::paramtype::stax,_station2))=sta2xyz(0)/ ivg::param_unit_fac.at( ivg::paramtype::stax );

--- a/src/ivg/obs.h
+++ b/src/ivg/obs.h
@@ -150,6 +150,13 @@ class Obs
         void set_feed_rotation( double feed1, double feed2 );
         /**
         *  \b Description: \n
+        *        Method to set phase center offset for both stations
+        *  \param [in] [double] vertical phase center offset for station 1 [m]
+        *              [double] vertical phase center offset for station 2 [m]
+        */
+        void set_phase_center_offset( double pco1, double pco2 );
+        /**
+        *  \b Description: \n
         *        Method to set cable calibration correction
         *  \param [in] [double] cable calibration correction for station 1
         *              [double] cable calibration correction for station 2

--- a/src/ivg/param.h
+++ b/src/ivg/param.h
@@ -27,11 +27,11 @@ namespace ivg
 {
 
 //Parameter Type
-                                enum paramtype {        stax,        stay,        staz,    clo,         zwd,         ngr,         egr,          xpo,          ypo,            ut1,         nutx,         nuty,      ra,     dec,     cbr,    nutln,     nutob,    blcl, atbr, MAXPARAM };
-const std::vector<std::string> paramtype_str = {      "stax",      "stay",      "staz",  "clo",    "zwd"   ,       "ngr",       "egr",        "xpo",        "ypo",          "ut1",       "nutx",       "nuty",    "ra",   "dec",   "cbr",  "nutln",   "nutob",  "blcl",  "atbr"};
-const std::vector<std::string> paramtype_snx(  {      "STAX",      "STAY",      "STAZ",  "CLO",    "TROTOT",    "TGNTOT",    "TGETOT",        "XPO",        "YPO",          "UT1",      "NUT_X",      "NUT_Y", "RS_RA", "RS_DE", "CL_BR", "NUT_LN",  "NUT_OB", "BL_CL", "AT_CR"} );
-const std::vector<std::string> paramtype_unit( {      "m"   ,         "m",         "m",    "s",         "m",         "m",         "m",        "mas",        "mas",           "ms",        "mas",        "mas",   "rad",   "rad",     "s",    "mas",     "mas",     "s",     "m"} );
-const std::vector<double> param_unit_fac(      { ivg::c*1e-2, ivg::c*1e-2, ivg::c*1e-2, 1.0e-1, ivg::c*1e-1, ivg::c*1e-2, ivg::c*1e-2, ivg::rad2mas, ivg::rad2mas, ivg::rad2s*1e3, ivg::rad2mas, ivg::rad2mas,     1.0,     1.0,  1.0e-1,      1.0,       1.0,  1.0e-1, ivg::c*1e-1} );
+                                enum paramtype {        stax,        stay,        staz,    clo,         zwd,         ngr,         egr,          xpo,          ypo,            ut1,         nutx,         nuty,      ra,     dec,     cbr,    nutln,     nutob,    blcl, atbr,        pco, MAXPARAM };
+const std::vector<std::string> paramtype_str = {      "stax",      "stay",      "staz",  "clo",    "zwd"   ,       "ngr",       "egr",        "xpo",        "ypo",          "ut1",       "nutx",       "nuty",    "ra",   "dec",   "cbr",  "nutln",   "nutob",  "blcl",  "atbr",      "pco"};
+const std::vector<std::string> paramtype_snx(  {      "STAX",      "STAY",      "STAZ",  "CLO",    "TROTOT",    "TGNTOT",    "TGETOT",        "XPO",        "YPO",          "UT1",      "NUT_X",      "NUT_Y", "RS_RA", "RS_DE", "CL_BR", "NUT_LN",  "NUT_OB", "BL_CL", "AT_CR",      "PCO"} );
+const std::vector<std::string> paramtype_unit( {      "m"   ,         "m",         "m",    "s",         "m",         "m",         "m",        "mas",        "mas",           "ms",        "mas",        "mas",   "rad",   "rad",     "s",    "mas",     "mas",     "s",     "m",         "m"} );
+const std::vector<double> param_unit_fac(      { ivg::c*1e-2, ivg::c*1e-2, ivg::c*1e-2, 1.0e-1, ivg::c*1e-1, ivg::c*1e-2, ivg::c*1e-2, ivg::rad2mas, ivg::rad2mas, ivg::rad2s*1e3, ivg::rad2mas, ivg::rad2mas,     1.0,     1.0,  1.0e-1,      1.0,       1.0,  1.0e-1, ivg::c*1e-1, ivg::c*1e-2} );
 
 //enum paramtype { stax, stay, staz, clo, zwd, ngr, egr, xpo, xpor, ypo, ypor, ut1, lod, nutx, nuty, ra, dec };
 //const std::vector<std::string> paramtype_str = { "stax", "stay", "staz", "clo", "zwd", "ngr", "egr", "xpo", "xpor", "ypo", "ypor", "ut1", "lod", "nutx", "nuty", "ra", "dec" };

--- a/src/ivg/param_list.cpp
+++ b/src/ivg/param_list.cpp
@@ -76,6 +76,7 @@ Param_list::Param_list(ivg::Trf &trf, ivg::Crf &crf, ivg::Eop_series &eops, ivg:
         _params.push_back(ivg::Param(ivg::paramtype::zwd, sta_name, epoch));
         _params.push_back(ivg::Param(ivg::paramtype::ngr, sta_name, epoch));
         _params.push_back(ivg::Param(ivg::paramtype::egr, sta_name, epoch));
+        _params.push_back(ivg::Param(ivg::paramtype::pco, sta_name, epoch));
     }
 
     ivg::Matrix erp = eops.calc_erp(epoch);
@@ -155,7 +156,8 @@ void Param_list::modify_parameterization( std::string dbname, Setting &setup,
         { "nut", {ivg::paramtype::nutx,ivg::paramtype::nuty}} ,
         { "gradients", {ivg::paramtype::ngr,ivg::paramtype::egr}} ,
         { "sources", {ivg::paramtype::ra,ivg::paramtype::dec}},
-        { "bl_clocks", {ivg::paramtype::blcl}}
+        { "bl_clocks", {ivg::paramtype::blcl}},
+        { "pco", {ivg::paramtype::pco}}
     };
 
     // only if nutobln exists in the config-file, take it into account (for sinex combination dgfi)
@@ -183,7 +185,8 @@ void Param_list::modify_parameterization( std::string dbname, Setting &setup,
          vector<string> altnames;
         // select relevant param names
         if( param_iter->first == "stations" || param_iter->first == "zwd" ||
-                param_iter->first == "gradients"  || param_iter->first == "clocks" )
+                param_iter->first == "gradients"  || param_iter->first == "clocks" ||
+                param_iter->first == "pco" )
 	  {
             names = sta_names;
 	   

--- a/src/ivg/scan.h
+++ b/src/ivg/scan.h
@@ -52,6 +52,7 @@ class Scan
             ivg::Troposphere tropo;
             double cable_cal;
             double feed_rotation;
+            double phase_center_height;   // vertical phase center offset [m]
             double clo0;
         };
 

--- a/src/ivg/session_inout.cpp
+++ b/src/ivg/session_inout.cpp
@@ -1538,13 +1538,28 @@ void Session_inout::_read_vgosdb(ivg::Session *session_ptr, Setting *setup, cons
             {
                  for( int i=0; i<(*(session_ptr->_handling))["handling"]["ignore_cable_cal"].getLength(); ++i )
                  {
-                     string station = (*(session_ptr->_handling))["handling"]["ignore_cable_cal"][i];                 
+                     string station = (*(session_ptr->_handling))["handling"]["ignore_cable_cal"][i];
                      if( station == sta1 )
                          cable_cal1 = 0.0;
                      else if( station == sta2 )
                          cable_cal2 = 0.0;
-                 }                                   
+                 }
             }
+
+            double pco1 = 0.0;
+            double pco2 = 0.0;
+            if((bool)(*(session_ptr->_handling)).exists("handling") &&
+               (bool)((*(session_ptr->_handling))["handling"]).exists("phase_center_offset"))
+            {
+                for(int i=0; i<(*(session_ptr->_handling))["handling"]["phase_center_offset"].getLength(); ++i)
+                {
+                    string station = (*(session_ptr->_handling))["handling"]["phase_center_offset"][i][0];
+                    double val     = (*(session_ptr->_handling))["handling"]["phase_center_offset"][i][1];
+                    if( station == sta1 ) pco1 = val;
+                    else if( station == sta2 ) pco2 = val;
+                }
+            }
+            obs_new.set_phase_center_offset( pco1, pco2 );
 
             double temp1 = aux_data[sta1]["TempC"].at(data_idx1); // unit celsius
             double press1 = aux_data[sta1]["AtmPres"].at(data_idx1); // unit hPa


### PR DESCRIPTION
## Summary

- Adds PCO as an a priori correction to the phase delay model: `delta_tau = (h_pco2·sin(el2) − h_pco1·sin(el1)) / c`
- Adds PCO as an estimable per-station parameter (degree-0 polynom) in combined solutions
- All PCO code paths are gated on `delaytype == 'p'` — group-delay-only sessions are completely unaffected

## Physics

The electrical phase center of a VLBI antenna is offset vertically from the antenna reference point by `h_pco`. A source at elevation `el` arrives from a path length `h_pco·sin(el)` shorter than the reference point path. For a baseline, the differential contribution to the delay is:

```
delta_tau = ( h_pco2·sin(el2) − h_pco1·sin(el1) ) / c
```

This projects directly onto the UP component of the baseline in least squares. Phase delay solutions on the Ny Ålesund 1 km baseline show ~1 cm larger UP component than group delay solutions, consistent with a differential PCO between the two antennas.

## Config usage

**Handling config** (a priori correction, optional — unlisted stations default to 0.0):
```
handling:
{
    handling:
    {
        phase_center_offset = ( ("NYA13S", 0.01), ("NYALES20", 0.0) );
    }
}
```

**PARAMS config** (enable estimation, optional):
```
pco:
{
    polynom: { degree: 0;  cnstr: [ 0.05 ]; };
};
```
If absent, PCO is corrected by the a priori but not freely estimated.

## Files changed

`scan.h`, `obs.h`, `obs.cpp`, `param.h`, `param_list.cpp`, `session_inout.cpp`

## Test plan

- [ ] Phase delay solution with all PCO = 0 → UP offset ~1 cm (baseline unchanged)
- [ ] Set `phase_center_offset = (("NYA13S", 0.01))` → UP offset drops to ~0
- [ ] Combined phase+group solution with `cnstr: [0.05]` → estimated PCO converges to ~1 cm
- [ ] Group-delay-only run with no PCO config → identical results to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)